### PR TITLE
Add AXFR and TSIG support for monitoring complete zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Supply a configuration file path with `-config` (optionally, defaults to `/etc/d
 
 ### Support for authoritative servers (AXFR)
 
-If `[[zones]]` are configured, the resolvers specified with `-resolvers` must be configured to accept zone transfers (AXFR queries) from the machine running prometheus-dnssec-exporter.  Recursive resolvers do not support zone transfers.
+If `[[zones]]` are configured, the resolvers specified with `-resolvers` must be configured to accept zone transfers (AXFR queries), optionally secured with a TSIG key, from the machine running prometheus-dnssec-exporter.  Recursive resolvers do not support zone transfers.
+
+If a TSIG `key` is configured for a zone, a matching `[[keys]]` configuration must exist.
 
 It is considered impolite to send AXFR queries to public resolvers (e.g. Cloudflare, Google, Quad9).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ the number of days until the first one expires will be returned.  If the record
 is not signed of the signature cannot be validated, this metric will contain a
 bogus timestamp.
 
+If a zone is monitored, this metric will be calculated for the earliest record
+to expire in the zone.
+
 ### Gauge: `dnssec_zone_record_earliest_rrsig_expiry`
 
 Earliest expiring RRSIG covering the record on resolver in unixtime.
@@ -50,6 +53,9 @@ Labels:
 If more than one RRSIG covers the record, the expiration time returned will be
 of the one that expires earliest.  If the record does not resolve or cannot be
 validated, this metric will be absent.
+
+If a zone is monitored, this metric will be calculated for the earliest record
+to expire in the zone.
 
 ### Gauge: `dnssec_zone_record_resolves`
 
@@ -88,6 +94,14 @@ This metric will return 1 only if the record resolves **and** validates.
 Supply a configuration file path with `-config` (optionally, defaults to `/etc/dnssec-checks`). Uses [TOML](https://github.com/toml-lang/toml).
 
 [Sample configuration file](config.sample)
+
+### Support for authoritative servers (AXFR)
+
+If `[[zones]]` are configured, the resolvers specified with `-resolvers` must be configured to accept zone transfers (AXFR queries) from the machine running prometheus-dnssec-exporter.  Recursive resolvers do not support zone transfers.
+
+It is considered impolite to send AXFR queries to public resolvers (e.g. Cloudflare, Google, Quad9).
+
+Run separate instances of prometheus-dnssec-exporter to monitor zones on authoritative servers as well as records on public resolvers.
 
 ## Prometheus target
 

--- a/config.sample
+++ b/config.sample
@@ -7,3 +7,6 @@
   zone = "verisigninc.com"
   record = "@"
   type = "SOA"
+
+#[[zones]]
+#  zone = "example.com"

--- a/config.sample
+++ b/config.sample
@@ -8,5 +8,12 @@
   record = "@"
   type = "SOA"
 
+#[[keys]]
+#  name = "mysecretkey."
+#  algorithm = "hmac-sha256."
+#  # From e.g. tsig-keygen(1)
+#  secret = "mvgDxfYTSe8L+pp7h4r+PIeTc67YTPhGWZrhmIi2Rpo="
+
 #[[zones]]
 #  zone = "example.com"
+#  key = "mysecretkey."

--- a/main.go
+++ b/main.go
@@ -27,6 +27,10 @@ type Records struct {
 	Type   string
 }
 
+type Zones struct {
+	Zone string
+}
+
 type Logger interface {
 	Print(v ...interface{})
 	Printf(format string, v ...interface{})
@@ -34,6 +38,7 @@ type Logger interface {
 
 type Exporter struct {
 	Records []Records
+	Zones []Zones
 
 	records  *prometheus.GaugeVec
 	resolves *prometheus.GaugeVec
@@ -234,6 +239,15 @@ func main() {
 
 	if err := toml.NewDecoder(f).Decode(exporter); err != nil {
 		log.Fatalf("couldn't parse configuration file: %v", err)
+	}
+
+	for _, zone := range exporter.Zones {
+		var rec Records
+		rec.Zone = zone.Zone
+		rec.Record = "@"
+		rec.Type = "AXFR"
+
+		exporter.Records = append(exporter.Records, rec)
 	}
 
 	prometheus.MustRegister(exporter)

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,8 @@ type opts struct {
 	rcode           int
 	unauthenticated bool
 	noedns0support  bool
+	doublesign      bool
+	authoritative   bool
 }
 
 func nullLogger() *log.Logger {
@@ -65,43 +67,101 @@ func runServer(t *testing.T, opts opts) ([]string, func()) {
 			Minttl:  60,
 		}
 
-		switch q.Qtype {
-
-		case dns.TypeSOA:
-
-			rrHeader := dns.RR_Header{
+		ns := &dns.NS{
+			Hdr: dns.RR_Header{
 				Name:   q.Name,
-				Rrtype: dns.TypeRRSIG,
+				Rrtype: dns.TypeNS,
 				Class:  dns.ClassINET,
 				Ttl:    3600,
-			}
-			msg.Answer = append(msg.Answer, soa)
-
-			if opts.noedns0support {
-				break
-			}
-
-			rrsig := &dns.RRSIG{
-				Hdr:         rrHeader,
-				TypeCovered: dns.TypeSOA,
-				Algorithm:   dnskey.Algorithm,
-				Labels:      uint8(dns.CountLabel(q.Name)),
-				OrigTtl:     3600,
-				Expiration:  uint32(opts.expires.Unix()),
-				Inception:   uint32(opts.signed.Unix()),
-				KeyTag:      dnskey.KeyTag(),
-				SignerName:  q.Name,
-			}
-
-			if err := rrsig.Sign(privkey.(*ecdsa.PrivateKey), []dns.RR{soa}); err != nil {
-				t.Fatalf("couldn't sign SOA record: %v", err)
-			}
-
-			msg.Answer = append(msg.Answer, rrsig)
-
+			},
+			Ns:      "ns1.example.org.",
 		}
 
-		msg.AuthenticatedData = !opts.unauthenticated && !opts.noedns0support
+		rrHeader := dns.RR_Header{
+			Name:   q.Name,
+			Rrtype: dns.TypeRRSIG,
+			Class:  dns.ClassINET,
+			Ttl:    3600,
+		}
+
+		rrsig_soa := &dns.RRSIG{
+			Hdr:         rrHeader,
+			TypeCovered: dns.TypeSOA,
+			Algorithm:   dnskey.Algorithm,
+			Labels:      uint8(dns.CountLabel(q.Name)),
+			OrigTtl:     3600,
+			Expiration:  uint32(opts.expires.Unix()),
+			Inception:   uint32(opts.signed.Unix()),
+			KeyTag:      dnskey.KeyTag(),
+			SignerName:  q.Name,
+		}
+
+		// For double signature tests: expires in the past
+		rrsig_soa2 := &dns.RRSIG{
+			Hdr:         rrHeader,
+			TypeCovered: dns.TypeSOA,
+			Algorithm:   dnskey.Algorithm,
+			Labels:      uint8(dns.CountLabel(q.Name)),
+			OrigTtl:     3600,
+			Expiration:  uint32(time.Now().Add(-time.Hour).Unix()),
+			Inception:   uint32(opts.signed.Unix()),
+			KeyTag:      dnskey.KeyTag(),
+			SignerName:  q.Name,
+		}
+
+		// For AXFR tests: expires before SOA
+		rrsig_ns := &dns.RRSIG{
+			Hdr:         rrHeader,
+			TypeCovered: dns.TypeNS,
+			Algorithm:   dnskey.Algorithm,
+			Labels:      uint8(dns.CountLabel(q.Name)),
+			OrigTtl:     3600,
+			Expiration:  uint32(opts.expires.Add(-time.Hour).Unix()),
+			Inception:   uint32(opts.signed.Unix()),
+			KeyTag:      dnskey.KeyTag(),
+			SignerName:  q.Name,
+		}
+
+		if err := rrsig_soa.Sign(privkey.(*ecdsa.PrivateKey), []dns.RR{soa}); err != nil {
+			t.Fatalf("couldn't sign SOA record: %v", err)
+		}
+
+		if err := rrsig_soa2.Sign(privkey.(*ecdsa.PrivateKey), []dns.RR{soa}); err != nil {
+			t.Fatalf("couldn't sign SOA record: %v", err)
+		}
+
+		if err := rrsig_ns.Sign(privkey.(*ecdsa.PrivateKey), []dns.RR{ns}); err != nil {
+			t.Fatalf("couldn't sign NS record: %v", err)
+		}
+
+		switch q.Qtype {
+		case dns.TypeSOA:
+			msg.Answer = append(msg.Answer, soa)
+			if ! opts.noedns0support {
+				msg.Answer = append(msg.Answer, rrsig_soa)
+				if opts.doublesign {
+					msg.Answer = append(msg.Answer, rrsig_soa2)
+				}
+			}
+		case dns.TypeNS:
+			msg.Answer = append(msg.Answer, ns)
+			if ! opts.noedns0support {
+				msg.Answer = append(msg.Answer, rrsig_ns)
+			}
+		case dns.TypeAXFR:
+			msg.Answer = append(msg.Answer, soa)
+			msg.Answer = append(msg.Answer, rrsig_soa)
+			if opts.doublesign {
+				msg.Answer = append(msg.Answer, rrsig_soa2)
+			}
+			msg.Answer = append(msg.Answer, ns)
+			msg.Answer = append(msg.Answer, rrsig_ns)
+			msg.Answer = append(msg.Answer, soa)
+		}
+
+		msg.Authoritative = opts.authoritative || q.Qtype == dns.TypeAXFR
+		msg.AuthenticatedData = !opts.unauthenticated && !opts.noedns0support &&
+			!opts.authoritative && q.Qtype != dns.TypeAXFR
 		msg.Rcode = opts.rcode
 
 		rw.WriteMsg(msg)
@@ -139,11 +199,13 @@ func runServer(t *testing.T, opts opts) ([]string, func()) {
 func TestExpirationOK(t *testing.T) {
 
 	addr, cancel := runServer(t, opts{})
+	record := Records{"example.org", "@", "SOA"}
+
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	_, exp := e.resolve("example.org", "@", "SOA", addr[0])
+	_, exp := e.resolve(&record, addr[0])
 
 	if exp.Before(time.Now()) {
 		t.Fatalf("expected expiration to be in the future, was: %v", exp)
@@ -157,12 +219,13 @@ func TestExpired(t *testing.T) {
 		signed:  time.Now().Add(14 * 24 * time.Hour),
 		expires: time.Now().Add(-time.Hour),
 	})
+	record := Records{"example.org", "@", "SOA"}
 
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	_, exp := e.resolve("example.org", "@", "SOA", addr[0])
+	_, exp := e.resolve(&record, addr[0])
 
 	if exp.After(time.Now()) {
 		t.Fatalf("expected expiration to be in the past, was: %v", exp)
@@ -176,12 +239,13 @@ func TestValid(t *testing.T) {
 		signed:  time.Now().Add(14 * 24 * time.Hour),
 		expires: time.Now().Add(-time.Hour),
 	})
+	record := Records{"example.org", "@", "SOA"}
 
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	valid, _ := e.resolve("example.org", "@", "SOA", addr[0])
+	valid, _ := e.resolve(&record, addr[0])
 
 	if !valid {
 		t.Fatal("expected valid result")
@@ -194,12 +258,13 @@ func TestInvalidError(t *testing.T) {
 	addr, cancel := runServer(t, opts{
 		rcode: dns.RcodeServerFailure,
 	})
+	record := Records{"example.org", "@", "SOA"}
 
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	valid, _ := e.resolve("example.org", "@", "SOA", addr[0])
+	valid, _ := e.resolve(&record, addr[0])
 
 	if valid {
 		t.Fatal("expected invalid result")
@@ -212,12 +277,13 @@ func TestInvalidUnauthenticated(t *testing.T) {
 	addr, cancel := runServer(t, opts{
 		unauthenticated: true,
 	})
+	record := Records{"example.org", "@", "SOA"}
 
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	valid, _ := e.resolve("example.org", "@", "SOA", addr[0])
+	valid, _ := e.resolve(&record, addr[0])
 
 	if valid {
 		t.Fatal("expected invalid result")
@@ -230,15 +296,126 @@ func TestNoEDNS0Support(t *testing.T) {
 	addr, cancel := runServer(t, opts{
 		noedns0support: true,
 	})
+	record := Records{"example.org", "@", "SOA"}
 
 	defer cancel()
 
 	e := NewDNSSECExporter(time.Second, addr, nullLogger())
 
-	valid, _ := e.resolve("example.org", "@", "SOA", addr[0])
+	valid, _ := e.resolve(&record, addr[0])
 
 	if valid {
 		t.Fatal("expected invalid result")
+	}
+
+}
+
+func TestDoubleSignature(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{
+		doublesign: true,
+	})
+	record := Records{"example.org", "@", "SOA"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	_, exp := e.resolve(&record, addr[0])
+
+	if exp.After(time.Now()) {
+		t.Fatalf("expected expiration to be in the past, was: %v", exp)
+	}
+
+}
+
+func TestAuthoritativeValid(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{
+		authoritative: true,
+	})
+	record := Records{"example.org", "@", "SOA"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	valid, _ := e.resolve(&record, addr[0])
+
+	if !valid {
+		t.Fatal("expected valid result")
+	}
+
+}
+
+func TestAxfrValid(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{})
+	record := Records{"example.org", "@", "AXFR"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	valid, _ := e.resolve(&record, addr[0])
+
+	if !valid {
+		t.Fatal("expected valid result")
+	}
+
+}
+
+func TestAxfrExpiresFirst(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{})
+	record := Records{"example.org", "@", "AXFR"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	e.resolve(&record, addr[0])
+
+	if record.Type != "NS" {
+		t.Fatalf("Expected NS to expire first, got: %v", record.Type)
+	}
+
+}
+
+func TestAxfrExpiresFirstDoubleSoa(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{
+		doublesign: true,
+	})
+	record := Records{"example.org", "@", "AXFR"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	e.resolve(&record, addr[0])
+
+	if record.Type != "SOA" {
+		t.Fatalf("Expected SOA to expire first, got: %v", record.Type)
+	}
+
+}
+
+func TestAxfrRefused(t *testing.T) {
+
+	addr, cancel := runServer(t, opts{
+		rcode: dns.RcodeRefused,
+	})
+	record := Records{"example.org", "@", "AXFR"}
+
+	defer cancel()
+
+	e := NewDNSSECExporter(time.Second, addr, nullLogger())
+
+	valid, _ := e.resolve(&record, addr[0])
+
+	if valid {
+		t.Fatalf("Expected invalid result")
 	}
 
 }


### PR DESCRIPTION
DNSSEC pipelines can fail in so many interesting ways.

With this set of patches, prometheus-dnssec-exporter can transfer zones from authoritative servers using AXFR, optionally protected with TSIG.  It will then report the earliest record that will expire in the zone.

Note that, because of the way prometheus-dnssec-exporter is designed, it's not possible to monitor zones on authoritative servers as well as records on public resolvers from the same process.  I have some ideas to improve this, but they'll be fiddly to implement without breaking existing configurations.

This patch is fully compatible with existing configurations.